### PR TITLE
[sai_ptf]fix thrift armhf build

### DIFF
--- a/src/thrift_0_14_1/Makefile
+++ b/src/thrift_0_14_1/Makefile
@@ -20,16 +20,10 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	tar -xvzf ./thrift_$(THRIFT_VERSION).tar.gz
 	if [ -f thrift.patch/series ]; then pushd thrift-$(THRIFT_VERSION) && QUILT_PATCHES=../thrift.patch quilt push -a; [ -d .pc ] && rm -rf .pc; popd; fi
 
-	if [ $(CONFIGURED_ARCH) == armhf ]; then
-		alias python=python3
-	fi	
 	pushd thrift-$(THRIFT_VERSION)
 	DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -d -rfakeroot -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/
-	if [ $(CONFIGURED_ARCH) == armhf ]; then
-		unalias python
-	fi
 
 $(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)

--- a/src/thrift_0_14_1/thrift.patch/0005-Fix-build-rules-python.patch
+++ b/src/thrift_0_14_1/thrift.patch/0005-Fix-build-rules-python.patch
@@ -1,0 +1,13 @@
+diff --git a/debian/rules b/debian/rules
+index 3a50319ee..4b2a05932 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -86,7 +86,7 @@ clean:
+ 	dh_testroot
+ 	rm -f build-arch-stamp build-indep-stamp configure-stamp
+ 
+-	cd $(CURDIR)/lib/py && python setup.py clean --all
++	if [ -z $(shell command -v python) ]; then cd $(CURDIR)/lib/py && python3 setup.py clean --all; else cd $(CURDIR)/lib/py && python setup.py clean --all; fi
+ 
+ 	# Add here commands to clean up after the build process.
+ 	-$(MAKE) clean

--- a/src/thrift_0_14_1/thrift.patch/series
+++ b/src/thrift_0_14_1/thrift.patch/series
@@ -3,3 +3,4 @@
 0003-Remove-minimist-packages.patch
 0004-Remove-underscore-packages.patch
 0002-cve-2017-1000487.patch
+0005-Fix-build-rules-python.patch


### PR DESCRIPTION
in armhf buidl failed as no python command

how
add a checker for different python command, python/python3 and base on result use the right command

verify
container build

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

