### PR TITLE
[Thrift_014[armhf]]Fix libboost_unit_test_framework.a not found issue

### DIFF
--- a/src/thrift_0_14_1/thrift.patch/0006-Fix-build-rules-boost-test.patch
+++ b/src/thrift_0_14_1/thrift.patch/0006-Fix-build-rules-boost-test.patch
@@ -1,0 +1,12 @@
+diff --git a/debian/rules b/debian/rules
+index 3a50319ee..4b2a05932 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -65,6 +65,7 @@ build-compiler-stamp: configure-stamp
+ 
+ build-libcpp-stamp: configure-stamp build-compiler-stamp
+ 	# Compile C++ library
++	if [ -f /usr/lib/arm-linux-gnueabihf/libboost_unit_test_framework.a ]; then sudo ln -s /usr/lib/arm-linux-gnueabihf/libboost_unit_test_framework.a /usr/lib/libboost_unit_test_framework.a ; fi
+ 	$(MAKE) -C $(CURDIR)/lib/cpp
+ 	touch $@
+ 

--- a/src/thrift_0_14_1/thrift.patch/series
+++ b/src/thrift_0_14_1/thrift.patch/series
@@ -4,3 +4,4 @@
 0004-Remove-underscore-packages.patch
 0002-cve-2017-1000487.patch
 0005-Fix-build-rules-python.patch
+0006-Fix-build-rules-boost-test.patch


### PR DESCRIPTION


Why
error happen build thirft in armhf

How
fix this issue, add a soft link for the dependent file

Verify
Build pipeline

Signed-off-by: richardyu-ms <richard.yu@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

